### PR TITLE
add exists method

### DIFF
--- a/PubSub/PubSubExtensions.cs
+++ b/PubSub/PubSubExtensions.cs
@@ -10,6 +10,19 @@ namespace PubSub
     {
         static private readonly Hub hub = new Hub();
 
+        static public bool Exists<T>( this object obj )
+        {
+            foreach ( var h in hub.handlers )
+            {
+                if ( h.Sender.Target.ToString() == obj.ToString() &&
+                    typeof(T) == h.Type )
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         static public void Publish<T>( this object obj )
         {
             hub.Publish( obj, default( T ) );


### PR DESCRIPTION
I wanted a way to know if a specific subscribe handler already exists. I added a method to the static extensions to get this from the internal collection.