### PR TITLE
Added a Publish() and Subscribe() method onto the Hub class to allow …

### DIFF
--- a/PubSub.Tests/HubTests.cs
+++ b/PubSub.Tests/HubTests.cs
@@ -228,5 +228,45 @@ namespace PubSub.Tests
             // assert
             Assert.AreEqual( 0, hub.handlers.Count );
         }
+
+        [TestMethod]
+        public void PublishExtensions()
+        {
+            // arrange
+            int callCount = 0;
+
+            this.Subscribe<Event>(new Action<Event>(a => callCount++));
+            this.Subscribe(new Action<Event>(a => callCount++));
+
+            // act
+            this.Publish(new Event());
+            this.Publish<SpecialEvent>(new SpecialEvent());
+
+            // assert
+            Assert.AreEqual(4, callCount);
+        }
+
+        [TestMethod]
+        public void PublishDirectlyToHub()
+        {
+            // arrange
+            int callCount = 0;
+            var myhub = new Hub();
+
+            // before change, this lies and subscribes to the static hub instead.
+            myhub.Subscribe<Event>(new Action<Event>(a => callCount++));
+            myhub.Subscribe(new Action<Event>(a => callCount++));
+
+            // act
+            
+            // before change, this uses the static hub in the Extensions.
+            myhub.Publish(new Event());
+            // before change, this uses myhub which has no listeners.
+            myhub.Publish<SpecialEvent>(new SpecialEvent());
+
+            // assert
+            Assert.AreEqual(4, callCount);
+
+        }
     }
 }

--- a/PubSub/Hub.cs
+++ b/PubSub/Hub.cs
@@ -17,6 +17,16 @@ namespace PubSub
         internal object locker = new object();
         internal List<Handler> handlers = new List<Handler>();
 
+        /// <summary>
+        /// Allow publishing directly onto this Hub.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="data"></param>
+        public void Publish<T>(T data = default(T))
+        {
+            Publish(this, data);
+        }
+
         public void Publish<T>( object sender, T data = default( T ) )
         {
             var handlerList = new List<Handler>( handlers.Count );
@@ -46,6 +56,16 @@ namespace PubSub
             {
                 ( (Action<T>) l.Action )( data );
             }
+        }
+
+        /// <summary>
+        /// Allow subscribing directly to this Hub.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="handler"></param>
+        public void Subscribe<T>(Action<T> handler)
+        {
+            Subscribe(this, handler);
         }
 
         public void Subscribe<T>( object sender, Action<T> handler )

--- a/PubSub/Hub.cs
+++ b/PubSub/Hub.cs
@@ -83,6 +83,14 @@ namespace PubSub
             }
         }
 
+        /// <summary>
+        /// Allow unsubscribing directly to this Hub.
+        /// </summary>
+        public void Unsubscribe()
+        {
+            Unsubscribe(this);
+        }
+
         public void Unsubscribe( object sender )
         {
             lock ( this.locker )
@@ -95,6 +103,25 @@ namespace PubSub
                     this.handlers.Remove( h );
                 }
             }
+        }
+
+        /// <summary>
+        /// Allow unsubscribing directly to this Hub.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        public void Unsubscribe<T>()
+        {
+            Unsubscribe<T>(this);
+        }
+
+        /// <summary>
+        /// Allow unsubscribing directly to this Hub.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="handler"></param>
+        public void Unsubscribe<T>(Action<T> handler = null)
+        {
+            Unsubscribe<T>(this, handler);
         }
 
         public void Unsubscribe<T>( object sender, Action<T> handler = null )


### PR DESCRIPTION
Hi.. I love the simplicity of this project. However I did find a significant bug and need for small change due to the use of the static instance of a Hub in the Extensions class. While it is very handy to use a static instance, in a multi-threaded web environment it typically causes dangers and users might want to limit an instance of a Hub to their current thread. I added the 2 methods to the Hub class to make it possible to directly use that hub.

I also added some test code to demonstrate the current extension methods for publish which weren't tested at all, as well as the direct use which actually did not work as someone would expect without this fix as far as I can tell.
