### PR TITLE
Added the ability to use tokens as a filtering mechanism

### DIFF
--- a/PubSub.Tests/CoreHubTests.cs
+++ b/PubSub.Tests/CoreHubTests.cs
@@ -244,6 +244,13 @@ namespace PubSub.Tests
             _hub.Publish(42, token2); //should be true
             Assert.AreEqual(2, callCount);
             
+            _hub.Unsubscribe();  //This shouldn't unsubscribe anything
+            Assert.AreEqual(_hub._handlers.Count, 2);
+
+            _hub.Unsubscribe(token1);  //This should unsubscribe token1
+            Assert.AreEqual(_hub._handlers.Count, 1);
+
+
         }
     }
 

--- a/PubSub.Tests/CoreHubTests.cs
+++ b/PubSub.Tests/CoreHubTests.cs
@@ -226,6 +226,25 @@ namespace PubSub.Tests
             // assert
             Assert.AreEqual(10, callCount);
         }
+
+        [TestMethod]
+        public void PubSubWithToken()
+        {
+            var callCount = 0;
+            string token1 = "token1";
+            string token2 = "token2";
+            _hub.Subscribe<bool>((b) => { callCount++;},token1);
+            _hub.Subscribe<int>((i)=>callCount++,token2);
+
+            _hub.Publish(true);  //There is no token with ""
+            _hub.Publish(true, token2); //There is no token2 with bool
+            _hub.Publish(true, token1); //should be true
+
+            Assert.AreEqual(1, callCount);
+            _hub.Publish(42, token2); //should be true
+            Assert.AreEqual(2, callCount);
+            
+        }
     }
 
     public class Event

--- a/PubSub.Tests/IocExtensionsTests.cs
+++ b/PubSub.Tests/IocExtensionsTests.cs
@@ -9,8 +9,8 @@ namespace PubSub.Tests
         private IPubSubPipelineFactory pubSubFactory;
         private ISubscriber subscriber;
         private IPublisher publisher;
-        private object sender;
-        private object preservedSender;
+        private string sender;
+        private string preservedSender;
 
         [TestInitialize]
         public void Setup()
@@ -18,8 +18,8 @@ namespace PubSub.Tests
             pubSubFactory = new PubSubPipelineFactory();
             subscriber = pubSubFactory.GetSubscriber();
             publisher = pubSubFactory.GetPublisher();
-            sender = new object();
-            preservedSender = new object();
+            sender = "sender";
+            preservedSender = "preservedSender";
         }
         
         [TestMethod]

--- a/PubSub/Ioc/Implementation/Publisher.cs
+++ b/PubSub/Ioc/Implementation/Publisher.cs
@@ -9,6 +9,6 @@
             this.hub = hub;
         }
 
-        public void Publish<T>(T data) => hub.Publish(data);
+        public void Publish<T>(T data, string token) => hub.Publish(data, token);
     }
 }

--- a/PubSub/Ioc/Implementation/Subscriber.cs
+++ b/PubSub/Ioc/Implementation/Subscriber.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 
 namespace PubSub
 {
@@ -6,21 +7,21 @@ namespace PubSub
     {
         private readonly Hub hub;
 
-        public Subscriber( Hub hub )
+        public Subscriber(Hub hub)
         {
             this.hub = hub;
         }
 
-        public bool Exists<T>( object subscriber ) => hub.Exists<T>( subscriber );
+        public bool Exists<T>(object subscriber, string token) => hub.Exists<T>(subscriber, token);
 
-        public bool Exists<T>( object subscriber, Action<T> handler ) => hub.Exists( subscriber, handler );
+        public bool Exists<T>(object subscriber, Action<T> handler, string token) => hub.Exists(subscriber, handler, token);
 
-        public void Subscribe<T>( object subscriber, Action<T> handler ) => hub.Subscribe( subscriber, handler );
+        public void Subscribe<T>(object subscriber, Action<T> handler, string token) => hub.Subscribe(subscriber, handler, token);
 
-        public void Unsubscribe( object subscriber ) => hub.Unsubscribe( subscriber );
+        public void Unsubscribe(object subscriber, string token = "") => hub.Unsubscribe(subscriber, token);
 
-        public void Unsubscribe<T>( object subscriber ) => hub.Unsubscribe( subscriber, (Action<T>) null );
+        public void Unsubscribe<T>(object subscriber, string token) => hub.Unsubscribe(subscriber, (Action<T>)null, token);
 
-        public void Unsubscribe<T>( object subscriber, Action<T> handler ) => hub.Unsubscribe( subscriber, handler );
+        public void Unsubscribe<T>(object subscriber, Action<T> handler, string token) => hub.Unsubscribe(subscriber, handler, token);
     }
 }

--- a/PubSub/Ioc/Interfaces/IPublisher.cs
+++ b/PubSub/Ioc/Interfaces/IPublisher.cs
@@ -2,6 +2,6 @@
 {
     public interface IPublisher
     {
-        void Publish<T>(T data);
+        void Publish<T>(T data, string token = "");
     }
 }

--- a/PubSub/Ioc/Interfaces/ISubscriber.cs
+++ b/PubSub/Ioc/Interfaces/ISubscriber.cs
@@ -4,11 +4,11 @@ namespace PubSub
 {
     public interface ISubscriber
     {
-        bool Exists<T>( object subscriber );
-        bool Exists<T>( object subscriber, Action<T> handler );
-        void Subscribe<T>( object subscriber, Action<T> handler );
-        void Unsubscribe( object subscriber );
-        void Unsubscribe<T>( object subscriber );
-        void Unsubscribe<T>( object subscriber, Action<T> handler );
+        bool Exists<T>( object subscriber, string token = "" );
+        bool Exists<T>( object subscriber, Action<T> handler, string token = "");
+        void Subscribe<T>( object subscriber, Action<T> handler, string token ="");
+        void Unsubscribe( object subscriber, string token = "");
+        void Unsubscribe<T>( object subscriber, string token = "");
+        void Unsubscribe<T>( object subscriber, Action<T> handler, string token = "");
     }
 }


### PR DESCRIPTION
I want to filter some messages to specifik subscribers. This had to be done manually before. Now it's possible to do with a simple messenger token.

example in PubSubWithToken()
