### PR TITLE
Issue #33 Unsubscribe is failing.  Allow Action<T> or Func<T, Task>

### DIFF
--- a/PubSub.Tests/ExtensionWithTaskTest.cs
+++ b/PubSub.Tests/ExtensionWithTaskTest.cs
@@ -64,23 +64,38 @@ namespace PubSub.Tests
             var hub = new Hub();
             var callCount = 0;
 
-            hub.Subscribe(new Action<Event>(a => callCount++));
-            hub.Subscribe(new Func<Event, Task>(e =>
+            var action = new Action<Event>(a => callCount++);
+            var func = new Func<Event, Task>(e =>
             {
                 return Task.Run(() =>
                 {
                     Thread.Sleep(200);
                     return callCount++;
                 });
-            }));
+            });
 
             // act
+            hub.Subscribe(action);
+            hub.Subscribe(func);
+
             hub.PublishAsync(new Event()).Wait();
             hub.PublishAsync(new SpecialEvent()).Wait();
             hub.PublishAsync<Event>().Wait();
 
             // assert
             Assert.AreEqual(6, callCount);
+
+            //act 2  
+            hub.Unsubscribe(action);
+            hub.Unsubscribe(func);
+
+            hub.PublishAsync(new Event()).Wait();
+            hub.PublishAsync(new SpecialEvent()).Wait();
+            hub.PublishAsync<Event>().Wait();
+
+            // assert 2
+            Assert.AreEqual(6, callCount);            
+
         }
     }
 }

--- a/PubSub/Core/Hub.cs
+++ b/PubSub/Core/Hub.cs
@@ -79,12 +79,20 @@ namespace PubSub
             Unsubscribe(this);
         }
 
-        public void Unsubscribe(object subscriber)
+        public void Unsubscribe(Delegate handler)
+        {
+            Unsubscribe(this, handler);
+        }
+
+        public void Unsubscribe(object subscriber, Delegate handler = null)
         {
             lock (_locker)
             {
                 var query = _handlers.Where(a => !a.Sender.IsAlive ||
                                                 a.Sender.Target.Equals(subscriber));
+
+                if (handler != null)
+                    query = query.Where(a => a.Action.Equals(handler));
 
                 foreach (var h in query.ToList())
                     _handlers.Remove(h);
@@ -105,12 +113,12 @@ namespace PubSub
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="handler"></param>
-        public void Unsubscribe<T>(Action<T> handler)
+        public void Unsubscribe<T>(Delegate handler)
         {
             Unsubscribe(this, handler);
         }
 
-        public void Unsubscribe<T>(object subscriber, Action<T> handler = null)
+        public void Unsubscribe<T>(object subscriber, Delegate handler = null)
         {
             lock (_locker)
             {


### PR DESCRIPTION
To work with PublishAsync Func<T, Task> is required and when trying to Unsubscribe it wouldn't find the delegate to remove the handler.  Changed code to allow a Delegate as that will allow Action<T> or Func<T, Task>