### PR TITLE
add method to check if there are any subscribers of type T

### DIFF
--- a/PubSub.Tests/CoreHubTests.cs
+++ b/PubSub.Tests/CoreHubTests.cs
@@ -246,6 +246,70 @@ namespace PubSub.Tests
             }
         }
 
+        [TestMethod]
+        public void Any_DetectsSubscriber() {
+            // arrange
+            _hub.Subscribe(new Action<Event>(a => { }));
+
+            // act
+            var typeExists = _hub.Any<Event>();
+
+            // assert
+            Assert.IsTrue(typeExists);
+        }
+
+        [TestMethod]
+        public void Any_DetectsSubscribers() {
+            // arrange
+            var actionOne = new Action<Event>(a => { });
+            var actionTwo = new Action<Event>(a => { });
+            var actionthree = new Action<SpecialEvent>(a => { });
+
+            _hub.Subscribe(actionOne);
+            _hub.Subscribe(actionTwo);
+            _hub.Subscribe(actionthree);
+
+            // act
+            var typeExists = _hub.Any<Event>();
+            var typeExistsSpecial = _hub.Any<SpecialEvent>();
+
+            // assert
+            Assert.IsTrue(typeExists);
+            Assert.IsTrue(typeExistsSpecial);
+        }
+
+        [TestMethod]
+        public void Any_DetectsSubscriberAfterOneRemoved() {
+            // arrange
+            var actionOne = new Action<Event>(a => { });
+            var actionTwo = new Action<Event>(a => { });
+
+            _hub.Subscribe(actionOne);
+            _hub.Subscribe(actionTwo);
+
+            // act
+            _hub.Unsubscribe(actionOne);
+            var typeExists = _hub.Any<Event>();
+
+            // assert
+            Assert.IsTrue(typeExists);
+        }
+
+        [TestMethod]
+        public void Any_DoesNotDetectSubscriber() {
+            // arrange
+            var actionOne = new Action<Event>(a => { });
+
+            // act
+            _hub.Subscribe(actionOne);
+            _hub.Publish<Event>();
+            _hub.Unsubscribe(actionOne);
+            var typeExists = _hub.Any<Event>();
+
+            // assert
+            Assert.IsFalse(typeExists);
+        }
+
         internal class Stuff
         {
             public Stuff(Hub hub)

--- a/PubSub/Core/Hub.cs
+++ b/PubSub/Core/Hub.cs
@@ -133,6 +133,15 @@ namespace PubSub
             }
         }
 
+        /// <summary>
+        ///     Check if any of type T are subscribed to this Hub.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>A bool indicating the presence of one or more subscribers of type T</returns>
+        public bool Any<T>() {
+            return GetAliveHandlers<T>().Any(handler => typeof(T) == handler.Type);
+        }
+
         public bool Exists<T>()
         {
             return Exists<T>(this);

--- a/PubSub/Ioc/Implementation/Subscriber.cs
+++ b/PubSub/Ioc/Implementation/Subscriber.cs
@@ -11,6 +11,8 @@ namespace PubSub
             this.hub = hub;
         }
 
+        public bool Any<T>() => hub.Any<T>();
+        
         public bool Exists<T>( object subscriber ) => hub.Exists<T>( subscriber );
 
         public bool Exists<T>( object subscriber, Action<T> handler ) => hub.Exists( subscriber, handler );

--- a/PubSub/Ioc/Interfaces/ISubscriber.cs
+++ b/PubSub/Ioc/Interfaces/ISubscriber.cs
@@ -4,6 +4,7 @@ namespace PubSub
 {
     public interface ISubscriber
     {
+        bool Any<T>();
         bool Exists<T>( object subscriber );
         bool Exists<T>( object subscriber, Action<T> handler );
         void Subscribe<T>( object subscriber, Action<T> handler );


### PR DESCRIPTION
Adds a new method `Any<T> `, which checks for handlers of type `T` without also testing referential equality of the subscriber. 